### PR TITLE
Fix for purchase invoice dimension item property order

### DIFF
--- a/src/methods/purchases.ts
+++ b/src/methods/purchases.ts
@@ -181,7 +181,20 @@ export class NetvisorPurchasesMethod extends NetvisorMethod {
    * @returns the added purhcase invoice's netvisor key
    */
   async purchaseInvoice(purchaseInvoice: PurchaseInvoice): Promise<string> {
-    const response = await this._client.post('purchaseinvoice.nv', buildXml({ root: { purchaseInvoice: purchaseInvoice } }));
+    // Dimension name and item must be in the order: dimension_name, dimension_item
+    const purchaseInvoiceProcessed: PurchaseInvoice = {
+      ...purchaseInvoice,
+      purchaseInvoiceLines: {
+        purchaseInvoiceLine: purchaseInvoice?.purchaseInvoiceLines.purchaseInvoiceLine.map((line => ({
+          ...line,
+          dimension: line.dimension ? line.dimension.map((d) => ({
+            dimensionName: d.dimensionName,
+            dimensionItem: d.dimensionItem,
+          })) : []
+        })))
+      }
+    };
+    const response = await this._client.post('purchaseinvoice.nv', buildXml({ root: { purchaseInvoice: purchaseInvoiceProcessed } }));
     return parseXml(response).replies.inserteddataidentifier;
   }
 


### PR DESCRIPTION
The Netvisor API requires that dimension name and item come in order: dimension_name, dimension_item. 

Netvisor API reports following error if not in correct order:
`INVALID_DATA :: Data form incorrect:. Validation of XML message failed: Could not validate xml: The element 'dimension' has invalid child element 'dimensionitem'. List of possible elements expected: 'dimensionname
`

Possibly same in dimensions of other objects as well, untested.